### PR TITLE
feat: added auto url links to documentation

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -20,6 +20,7 @@ markdown_extensions:
     # - pymdownx.highlight:
     #     linenums: true
     - pymdownx.superfences
+    - pymdownx.magiclink
     - smarty
     - toc:
         permalink: True


### PR DESCRIPTION
Added markdown plug-in that automatically turns urls into clickable links. 

From this repo:
https://facelessuser.github.io/pymdown-extensions/extensions/magiclink/